### PR TITLE
fix: handle duckdb errors by converting them to sqlite errors

### DIFF
--- a/datasette_parquet/ducky.py
+++ b/datasette_parquet/ducky.py
@@ -83,7 +83,16 @@ class DuckDatabase(Database):
             raise Exception('non-threaded mode not supported')
 
         def in_thread():
-            return fn(self.conn)
+            try:
+                return fn(self.conn)
+            except duckdb.OperationalError as e:
+                raise sqlite3.OperationalError(str(e))
+            except duckdb.ProgrammingError as e:
+                raise sqlite3.ProgrammingError(str(e))
+            except duckdb.InternalError as e:
+                raise sqlite3.InternalError(str(e))
+            except duckdb.DataError as e:
+                raise sqlite3.DatabaseError(str(e))
 
         return await asyncio.get_event_loop().run_in_executor(
             self.ds.executor, in_thread
@@ -94,7 +103,16 @@ class DuckDatabase(Database):
             raise Exception('non-threaded mode not supported')
 
         def in_thread():
-            return fn(self.conn)
+            try:
+                return fn(self.conn)
+            except duckdb.OperationalError as e:
+                raise sqlite3.OperationalError(str(e))
+            except duckdb.ProgrammingError as e:
+                raise sqlite3.ProgrammingError(str(e))
+            except duckdb.InternalError as e:
+                raise sqlite3.InternalError(str(e))
+            except duckdb.DataError as e:
+                raise sqlite3.DatabaseError(str(e))
 
         # We lie, we'll always block.
         return await asyncio.get_event_loop().run_in_executor(


### PR DESCRIPTION
This has been bothering me for some time now!

This makes it so that when a query fails, you get the chance to edit it still, rather than just showing the error on a fullscreen error page.

I was looking at the datasette source code, and it is only handling `sqlite3.DatabaseError` instances specifically: https://github.com/simonw/datasette/blob/55a709c480a1e7401b4ff6208f37a2cf7c682183/datasette/views/database.py#L374-L378

So, our best bet is to just convert any duckdb we might be getting into sqlite3 errors 🤷🏻 

@larsyencken once you'll merge this, you'll need to poetry-update the version of `datasette-parquet` version used on the `analytics` server for this to go into effect.

## Before/After

![CleanShot 2024-11-25 at 18 41 48](https://github.com/user-attachments/assets/cefaa460-138e-4040-b45d-1a66ef2ad7bb)
